### PR TITLE
Use InnoDB temp tables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,15 @@
  Changes
 =========
 
-2.0.0.1 (?) - Zenoss-owned - rebased from our local branch.
+2.0.0.2
+
+- https://jira.zenoss.com/browse/ZEN-25256
+
+  Cherry-picked from https://github.com/zodb/relstorage/pull/162
+  MySQL temporary tables now use the InnoDB engine instead of MyISAM.
+  See :pr:`162`.
+
+2.0.0.1 - Zenoss-owned - rebased from our local branch.
 
 - Connection patch. back to relstorage
   Fixes #29366: Add a log message and whatnot when the connection is recreated.

--- a/relstorage/adapters/mysql/mover.py
+++ b/relstorage/adapters/mysql/mover.py
@@ -30,31 +30,46 @@ class MySQLObjectMover(AbstractObjectMover):
     def on_store_opened(self, cursor, restart=False):
         """Create the temporary table for storing objects"""
         if restart:
-            stmt = "DROP TEMPORARY TABLE IF EXISTS temp_store"
+            # TRUNCATE is a DDL statement, even against a temporary
+            # table, and as such does an implicit transaction commit.
+            # Normally we want to avoid that, but here its OK since
+            # this method is called between transactions, as it were.
+            # TRUNCATE benchmarks (zodbshoot add) substantially faster
+            # (10157) than a DELETE (75xx) and moderately faster than
+            # a DROP/CREATE (9457). TRUNCATE is in the replication
+            # logs like a DROP/CREATE. (DROP TEMPORARY TABLE is *not*
+            # DDL and not transaction ending).
+            stmt = "TRUNCATE TABLE temp_store"
             cursor.execute(stmt)
-            stmt = "DROP TEMPORARY TABLE IF EXISTS temp_blob_chunk"
+            stmt = "TRUNCATE TABLE temp_blob_chunk"
+            cursor.execute(stmt)
+        else:
+            # InnoDB tables benchmark much faster for concurrency=2
+            # and 6 than MyISAM tables under both MySQL 5.5 and 5.7,
+            # at least on OS X 10.12. The OS X filesystem is single
+            # threaded, though, so the effects of flushing MyISAM tables
+            # to disk on every operation are probably magnified.
+
+            # note that the md5 column is not used if self.keep_history == False.
+            stmt = """
+            CREATE TEMPORARY TABLE temp_store (
+                zoid        BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+                prev_tid    BIGINT UNSIGNED NOT NULL,
+                md5         CHAR(32),
+                state       LONGBLOB
+            ) ENGINE InnoDB
+            """
             cursor.execute(stmt)
 
-        # note that the md5 column is not used if self.keep_history == False.
-        stmt = """
-        CREATE TEMPORARY TABLE temp_store (
-            zoid        BIGINT UNSIGNED NOT NULL PRIMARY KEY,
-            prev_tid    BIGINT UNSIGNED NOT NULL,
-            md5         CHAR(32),
-            state       LONGBLOB
-        ) ENGINE MyISAM
-        """
-        cursor.execute(stmt)
-
-        stmt = """
-        CREATE TEMPORARY TABLE temp_blob_chunk (
-            zoid        BIGINT UNSIGNED NOT NULL,
-            chunk_num   BIGINT UNSIGNED NOT NULL,
-                        PRIMARY KEY (zoid, chunk_num),
-            chunk       LONGBLOB
-        ) ENGINE MyISAM
-        """
-        cursor.execute(stmt)
+            stmt = """
+            CREATE TEMPORARY TABLE temp_blob_chunk (
+                zoid        BIGINT UNSIGNED NOT NULL,
+                chunk_num   BIGINT UNSIGNED NOT NULL,
+                            PRIMARY KEY (zoid, chunk_num),
+                chunk       LONGBLOB
+            ) ENGINE InnoDB
+            """
+            cursor.execute(stmt)
 
     @metricmethod_sampled
     def store_temp(self, cursor, batcher, oid, prev_tid, data):


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-25256
Cherry-picked from https://github.com/zodb/relstorage/pull/162
=============================================================

And truncate them.

For most things this seems to speed up writes by around 10% or more due
to the way the temp tables are allocated.

Tested on both 5.5 and 5.7.

I think the dropping was an attempt to make the tables statement-level
replication compatible, but since they weren't transactianal I don't
think that worked. They were also variable sized so I don't think there
were any speed benefits. It also didn't implicitly end the transaction,
but that's not a concern where this is called.

Here's a complete set of benchmarks against 5.7, comparing zodbshootout
with -c2 and -c6, -n 1000 and '-n 100 -s 256 --test-reps 200'. This
compares 2.0.0 with current master and this change, in that order.

** c=2,s=256 **                2.0.0   master   InnoDB
"Transaction",               mysql_hf
"Add 100 Objects",               8883     9199    10157
"Update 100 Objects",            9380     9169    10318

** c=6,s=256 **                 2.0.0    master   InnoDB
"Transaction",               mysql_hf
"Add 100 Objects",               ----     14913   15524
"Update 100 Objects",            ----     14914   15077

** c=6,s=128 **                 2.0.0    master   InnoDB
"Transaction",                mysql_hf
"Add 1000 Objects",              29815    31704    38506
"Update 1000 Objects",           28978    29030    29137

In all cases, InnoDB temp tables outperform, in some cases
substantially.

An earlier set of benchmarks taken against 5.5 (but prior to a rebase on
master, so not easily replicated). The absolute value difference in
numbers versus above is that these were taken with Py 3.4 while above
was py 2.7.

zodbshootout -c 2 shootout.conf -n 100 --test-reps 200 -r 1 -s 256

Before

** concurrency=2 **
"Transaction",               mysql_hf
"Add 100 Objects",               6493
"Update 100 Objects",            9636
"Read 100 Warm Objects",         9797
"Read 100 Cold Objects",         9336
"Read 100 Hot Objects",         37407
"Read 100 Steamin' Objects",   921761

** concurrency=6 **
"Transaction",               mysql_hf
"Add 100 Objects",              10574
"Update 100 Objects",           15492
"Read 100 Warm Objects",        19290
"Read 100 Cold Objects",        17051
"Read 100 Hot Objects",         72304
"Read 100 Steamin' Objects",  1590488

After

** concurrency=2 **
"Transaction",               mysql_hf
"Add 100 Objects",               7079
"Update 100 Objects",            9782
"Read 100 Warm Objects",         8726
"Read 100 Cold Objects",         9834
"Read 100 Hot Objects",         40004
"Read 100 Steamin' Objects",   937232

c=6
** concurrency=6 **
"Transaction",               mysql_hf
"Add 100 Objects",              10612
"Update 100 Objects",           15789
"Read 100 Warm Objects",        17501
"Read 100 Cold Objects",        16556
"Read 100 Hot Objects",         71868
"Read 100 Steamin' Objects",  1549534

zodbshootout -c 2 shootout.conf -n 100 --test-reps 200 -r 1 -s 96

** concurrency=2 **
"Transaction",               mysql_hf
"Add 100 Objects",              15547
"Update 100 Objects",           14337
"Read 100 Warm Objects",        12357
"Read 100 Cold Objects",        13686
"Read 100 Hot Objects",         54559
"Read 100 Steamin' Objects",   945789

"Transaction",               mysql_hf
"Add 100 Objects",              16968
"Update 100 Objects",           16184
"Read 100 Warm Objects",        13430
"Read 100 Cold Objects",        13557
"Read 100 Hot Objects",         54625
"Read 100 Steamin' Objects",   966802